### PR TITLE
Addressing Unexpected Behavior at Runtime

### DIFF
--- a/src/main/java/org/orecruncher/dsurround/runtime/audio/SoundFXProcessor.java
+++ b/src/main/java/org/orecruncher/dsurround/runtime/audio/SoundFXProcessor.java
@@ -136,7 +136,7 @@ public final class SoundFXProcessor {
         // Double suplex!  Queue the operation on the sound executor to do the config work.  This should queue in
         // behind any attempt at getting a sound source.
         entry.run(source -> {
-            var id = ((ISourceContext) source).getId();
+            int id = ((ISourceContext) source).getId();
             if (id > 0) {
                 final SourceContext ctx = new SourceContext();
                 ctx.attachSound(sound);


### PR DESCRIPTION
Issue: #29

potential-bug-fix

In class SoundFXProcessor:

Line: 146 <- Pointer of Issue
At runtime have unexpected behavior for solving `var id` as `byte`, but not as `int` for `sources`. `getId()` in `ISourceContext` class has return value of `int`.

For some reason in certain environments we have interesting behavior for solving this variable as `byte`, but expecting `int`.

Actual solution change type from `var` to `int` at line 139. Cause `ISourceContext.getId()` returns `int`.